### PR TITLE
Update TextView.swift

### DIFF
--- a/Aztec/Classes/TextKit/TextView.swift
+++ b/Aztec/Classes/TextKit/TextView.swift
@@ -226,10 +226,14 @@ open class TextView: UITextView {
     var defaultMissingImage: UIImage
     
     fileprivate var defaultAttributes: [NSAttributedStringKey: Any] {
-        let attributes: [NSAttributedStringKey: Any] = [
+        var attributes: [NSAttributedStringKey: Any] = [
             .font: defaultFont,
             .paragraphStyle: defaultParagraphStyle
         ]
+        
+         if let textColor = textColor {		
+             attributes[.foregroundColor] = textColor		
+         }
 
         return attributes
     }


### PR DESCRIPTION
Reinstated `textColor` as part of `typingAttributes` if set.

Fixes #1040

To test: set a `textColor` on the `TextView` and enter some text.
